### PR TITLE
Add domain keyword `linkedin`

### DIFF
--- a/Clash Rules.yaml
+++ b/Clash Rules.yaml
@@ -13,6 +13,7 @@
   - DOMAIN-SUFFIX,npmjs.com,$app_name
   - DOMAIN-SUFFIX,npmjs.org,$app_name
   - DOMAIN-KEYWORD,pornhub,$app_name
+  - DOMAIN-KEYWORD,linkedin,$app_name
   - DOMAIN-KEYWORD,notion,$app_name
   - DOMAIN-SUFFIX,yarnpkg.com,$app_name
   - DOMAIN-SUFFIX,pscdn.co,$app_name


### PR DESCRIPTION
news: https://www.scmp.com/tech/big-tech/article/3159968/linkedin-launches-new-app-china-without-social-feed-after-shutting